### PR TITLE
Codegen.exe bug fixes for config file default location and namespace parsing

### DIFF
--- a/package/Codegen/Program.cs
+++ b/package/Codegen/Program.cs
@@ -18,7 +18,7 @@ namespace Codegen
         public string ConfigFileName
         {
             get; set;
-        } = "Windows.UI.Xaml.json";
+        } = Path.Join(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), @"Windows.UI.Xaml.json");
 
         private static MrProperty GetProperty(MrLoadContext context, string type, string prop)
         {
@@ -541,7 +541,7 @@ namespace Codegen
             { "-cppout", new OptionDef (){ Description = "Custom path for C++ metadata files",   NumberOfParams = 2, Action = (p, v) => { p.cppOutPath = v; } } },
             { "-tsout", new OptionDef (){ Description = "Custom path for TS file", NumberOfParams = 2, Action = (p, v) => { p.tsOutPath = v; } } },
             { "-verbose", new OptionDef() { Description = "Output verbose info", NumberOfParams = 1, Action = (p, _) => { p.Verbose = true; }} },
-            { "-config", new OptionDef() { Description = "Config json file. Default is \"Windows.UI.Xaml.json\"", NumberOfParams = 2, Action = (p, v) => { p.ConfigFileName = v; }} },
+            { "-config", new OptionDef() { Description = "Config json file path. By default uses \"Windows.UI.Xaml.json\" in the same directory as this program", NumberOfParams = 2, Action = (p, v) => { p.ConfigFileName = v; }} },
         };
 
         static void Main(string[] args)
@@ -559,7 +559,7 @@ namespace Codegen
             }
             catch { }
             Console.WriteLine($"React-native-xaml Code generator {version}");
-            Console.WriteLine("https://github.com/asklar/react-native-xaml");
+            Console.WriteLine("https://github.com/microsoft/react-native-xaml");
             Console.WriteLine();
             var p = new Program();
             for (int i = 0; i < args.Length;)

--- a/package/Codegen/Util.cs
+++ b/package/Codegen/Util.cs
@@ -514,7 +514,8 @@ namespace Codegen
             {
                 // return the top level namespace
                 var ns = type.GetNamespace();
-                return ns.Substring(0, ns.IndexOf('.'));
+                var sep = ns.IndexOf('.');
+                return (sep != -1) ? ns.Substring(0, ns.IndexOf('.')) : ns;
             }
         }
         public static string GetNativePropsName(MrType type)

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-xaml",
   "title": "React Native Xaml",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "Allows using XAML directly, inside of a React Native Windows app",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
When following the steps on the [TechnicalGuide](https://github.com/microsoft/react-native-xaml/blob/main/TechnicalGuide.md), `codegen.exe` would produce the following error because it would look for the config file in the current working directory (instead of where the file was located by default):

```ps
Unhandled exception. System.IO.FileNotFoundException: Could not find file 'X:\...\myProject\Windows.UI.Xaml.json'.
File name: 'X:\...\myProject\Windows.UI.Xaml.json'
at System.IO.FileStream.ValidateFileHandle(SafeFileHandle fileHandle)
at System.IO.FileStream.CreateFileOpenHandle(FileMode mode, FileShare share, FileOptions options)
...
````

**Fixed by changing the default lookup path to be in the same directory as `Codegen.exe`**

----------

Additionally, there was a bug where [custom] XAML controls which were defined directly in a top-level namespace (e.g. `MyWinRtComponentNamespace.MyWinRtControl`) would result in `Codegen.exe` crashing.

**Fixed by adding in a check for this scenario in `Util.GetTSNamespace()`**

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-xaml/pull/131)