### PR TITLE
Add issue forms, set codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Catch-All
-* asklar
+* @microsoft/react-native-windows-write

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,37 @@
+name: Bug report
+description: File a bug report
+title: Describe the problem
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Your issue will be triaged by the team according to [this process](https://github.com/microsoft/react-native-windows/wiki/Triage-Process).
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Problem Description
+      description: Please enter a description of the issue. If you just have a question, please post on [Discussions](https://github.com/microsoft/react-native-windows/discussions).
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Steps To Reproduce
+      description: Provide a detailed list of steps that reproduce the issue.
+      placeholder: |
+        1.
+        2.
+  - type: textarea
+    attributes:
+      label: Expected Results
+      description: Describe what you expected to happen.
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Environment
+      description: |
+        Run the command `npx react-native info` in your terminal and copy the results here
+      value: "npx react-native info"
+      render: markdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+    - name: React Native for Windows
+      url: https://github.com/microsoft/react-native-windows/issues/new/choose
+      about: I have an issue with React Native for Windows that is not specific to react-native-xaml

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest a new feature or idea
+title: Your feature request
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Your issue will be triaged by the team according to [this process](https://github.com/microsoft/react-native-windows/wiki/Triage-Process).
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Summary
+      description: Brief explanation of the new API or change.
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Motivation
+      description: |
+        Why do this? What use cases does it support? What is the expected outcome?
+  - type: textarea
+    attributes:
+      label: Basic Example
+      description: |
+        If the proposal involves a new or changed API, include a basic code example. Omit this section if it's not applicable.
+  - type: textarea
+    attributes:
+      label: Open Questions
+      description: |
+        Please list any open issues that you think still need to be addressed.


### PR DESCRIPTION
- Add [issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms). Based these off those used in the RNW repo (including command for getting environment info).
- Retained availability of form-less issues using config.yml
- Set codeowners to the RNW write group

See similar issue forms changes:
- [React Native for Windows](https://github.com/microsoft/react-native-windows/pull/8639)
- [React Native desktop website](https://github.com/microsoft/react-native-windows-samples/pull/547)
- [React Native for macOS](https://github.com/microsoft/react-native-macos/pull/845)
- [WinUI](https://github.com/microsoft/microsoft-ui-xaml/pull/5947)
- [FURN](https://github.com/microsoft/fluentui-react-native/pull/1053)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-xaml/pull/139)