### PR TITLE
Remove UseJsi() Call from Example

### DIFF
--- a/example/windows/example/App.cpp
+++ b/example/windows/example/App.cpp
@@ -20,7 +20,6 @@ using namespace Windows::ApplicationModel;
 /// </summary>
 App::App() noexcept
 {
-    InstanceSettings().UseJsi(true);
 #if BUNDLE
     JavaScriptBundleFile(L"index.windows");
     InstanceSettings().UseWebDebugger(false);


### PR DESCRIPTION
**_Why_**
Remove UseJsi() Call from example app. This API was deprecated in 0.65; it causes the app build to fail. 

Fixes #180

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-xaml/pull/182)