### PR TITLE
Fix build break when RNW_REACTTAG_API is defined

### DIFF
--- a/change/react-native-xaml-6fc7297b-4bc6-41a0-89dd-464fd20a7485.json
+++ b/change/react-native-xaml-6fc7297b-4bc6-41a0-89dd-464fd20a7485.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fix build break when RNW_REACTTAG_API is defined",
-  "packageName": "react-native-xaml",
-  "email": "jthysell@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-xaml-6fc7297b-4bc6-41a0-89dd-464fd20a7485.json
+++ b/change/react-native-xaml-6fc7297b-4bc6-41a0-89dd-464fd20a7485.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix build break when RNW_REACTTAG_API is defined",
+  "packageName": "react-native-xaml",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package/CHANGELOG.json
+++ b/package/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "react-native-xaml",
   "entries": [
     {
+      "date": "Fri, 02 Sep 2022 20:18:20 GMT",
+      "tag": "react-native-xaml_v0.0.68",
+      "version": "0.0.68",
+      "comments": {
+        "patch": [
+          {
+            "author": "jthysell@microsoft.com",
+            "package": "react-native-xaml",
+            "comment": "Fix build break when RNW_REACTTAG_API is defined",
+            "commit": "67bf9b60f4b148ff2d673e17f6690e0de1aa590b"
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 01 Sep 2022 19:01:22 GMT",
       "tag": "react-native-xaml_v0.0.67",
       "version": "0.0.67",

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - react-native-xaml
 
-This log was last generated on Thu, 01 Sep 2022 19:01:22 GMT and should not be manually modified.
+This log was last generated on Fri, 02 Sep 2022 20:18:20 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.0.68
+
+Fri, 02 Sep 2022 20:18:20 GMT
+
+### Patches
+
+- Fix build break when RNW_REACTTAG_API is defined (jthysell@microsoft.com)
 
 ## 0.0.67
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-xaml",
   "title": "React Native Xaml",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "description": "Allows using XAML directly, inside of a React Native Windows app",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package/windows/ReactNativeXaml/Codegen/Version.g.h
+++ b/package/windows/ReactNativeXaml/Codegen/Version.g.h
@@ -7,4 +7,4 @@ THIS FILE WAS AUTOMATICALLY GENERATED, DO NOT MODIFY MANUALLY
 #define VERSION_MAJOR               0
 #define VERSION_MINOR               0
 #define VERSION_REVISION            0
-#define VERSION_BUILD               67
+#define VERSION_BUILD               68

--- a/package/windows/ReactNativeXaml/XamlMetadata.cpp
+++ b/package/windows/ReactNativeXaml/XamlMetadata.cpp
@@ -78,7 +78,7 @@ winrt::Windows::Foundation::IInspectable XamlMetadata::Create(const std::string&
 
 /*static*/ int64_t XamlMetadata::TagFromElement(xaml::DependencyObject const& element) {
 #ifdef RNW_REACTTAG_API 
-  return XamlHelper::GetTag(element);
+  return XamlHelper::GetReactTag(element);
 #else
   if (auto fe = element.try_as<FrameworkElement>()) {
     if (auto tagII = fe.Tag()) {
@@ -91,7 +91,7 @@ winrt::Windows::Foundation::IInspectable XamlMetadata::Create(const std::string&
 
 /*static*/ void XamlMetadata::ElementSetTag(xaml::DependencyObject const& element, int64_t tag) {
 #ifdef RNW_REACTTAG_API
-  XamlHelper::SetTag(element, tag);
+  XamlHelper::SetReactTag(element, tag);
 #else
   element.SetValue(FrameworkElement::TagProperty(), winrt::box_value(tag));
 #endif


### PR DESCRIPTION
It's `XamlHelper::GetReactTag` and `XamlHelper::SetReactTag`, not
`XamlHelper::GetTag` and `XamlHelper::SetTag`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-xaml/pull/222)