### PR TITLE
Restore ContentDialogClosed event

### DIFF
--- a/change/react-native-xaml-c82b4c3b-35a7-46d5-a07a-29075eeb4475.json
+++ b/change/react-native-xaml-c82b4c3b-35a7-46d5-a07a-29075eeb4475.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "restore OnContentDialogClosed since we need the return value from the show operation",
+  "packageName": "react-native-xaml",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-xaml-c82b4c3b-35a7-46d5-a07a-29075eeb4475.json
+++ b/change/react-native-xaml-c82b4c3b-35a7-46d5-a07a-29075eeb4475.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "restore OnContentDialogClosed since we need the return value from the show operation",
-  "packageName": "react-native-xaml",
-  "email": "asklar@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/package/CHANGELOG.json
+++ b/package/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "react-native-xaml",
   "entries": [
     {
+      "date": "Sun, 25 Sep 2022 05:36:46 GMT",
+      "tag": "react-native-xaml_v0.0.70",
+      "version": "0.0.70",
+      "comments": {
+        "patch": [
+          {
+            "author": "asklar@microsoft.com",
+            "package": "react-native-xaml",
+            "comment": "restore OnContentDialogClosed since we need the return value from the show operation",
+            "commit": "f1462114e7a7edc5202503d29e52064331890b6e"
+          }
+        ]
+      }
+    },
+    {
       "date": "Tue, 13 Sep 2022 21:38:24 GMT",
       "tag": "react-native-xaml_v0.0.69",
       "version": "0.0.69",

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - react-native-xaml
 
-This log was last generated on Tue, 13 Sep 2022 21:38:24 GMT and should not be manually modified.
+This log was last generated on Sun, 25 Sep 2022 05:36:46 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.0.70
+
+Sun, 25 Sep 2022 05:36:46 GMT
+
+### Patches
+
+- restore OnContentDialogClosed since we need the return value from the show operation (asklar@microsoft.com)
 
 ## 0.0.69
 

--- a/package/Codegen/Program.cs
+++ b/package/Codegen/Program.cs
@@ -225,12 +225,25 @@ namespace Codegen
                 var typeName = val.Substring(0, val.LastIndexOf('.'));
                 var eventName = val.Substring(val.LastIndexOf('.') + 1);
 
-                syntheticEvents.Add(new SyntheticProperty()
+                if (context.TryFindMrType(GetTypeNameFromJson(entry.Value), out var ptype))
                 {
-                    Name = eventName,
-                    DeclaringType = context.GetType(typeName),
-                    FakePropertyType = entry.Value.GetString(),
-                });
+                    syntheticEvents.Add(new SyntheticProperty()
+                    {
+                        Name = eventName,
+                        DeclaringType = context.GetType(typeName),
+                        PropertyType = ptype,
+                    });
+
+                }
+                else
+                {
+                    syntheticEvents.Add(new SyntheticProperty()
+                    {
+                        Name = eventName,
+                        DeclaringType = context.GetType(typeName),
+                        FakePropertyType = entry.Value.ToString()
+                    });
+                }
             }
 
 

--- a/package/Codegen/Windows.UI.Xaml.json
+++ b/package/Codegen/Windows.UI.Xaml.json
@@ -103,6 +103,7 @@
     }
   ],
   "syntheticEvents": {
+      "$xaml.Controls.ContentDialog.ContentDialogClosed": "$xaml.Controls.ContentDialogResult"
   },
   "propNameMapping": {
     "$xaml.Input.KeyboardAccelerator.Key": "virtualKey",

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-xaml",
   "title": "React Native Xaml",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "description": "Allows using XAML directly, inside of a React Native Windows app",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package/src/Props.ts
+++ b/package/src/Props.ts
@@ -2710,6 +2710,7 @@ export interface NativeContentDialogProps extends NativeContentControlProps {
   onPrimaryButtonClick?: (event: NativeSyntheticEvent<TypedEvent<NativeContentDialogButtonClickEventArgs>>) => void;
   onSecondaryButtonClick?: (event: NativeSyntheticEvent<TypedEvent<NativeContentDialogButtonClickEventArgs>>) => void;
   onCloseButtonClick?: (event: NativeSyntheticEvent<TypedEvent<NativeContentDialogButtonClickEventArgs>>) => void;
+  onContentDialogClosed?: (event: NativeSyntheticEvent<Enums.ContentDialogResult>) => void;
 }
 export interface NativeContentPresenterProps extends NativeFrameworkElementProps {
   type: 'Windows.UI.Xaml.Controls.ContentPresenter' |

--- a/package/windows/ReactNativeXaml/Codegen/TypeEvents.g.h
+++ b/package/windows/ReactNativeXaml/Codegen/TypeEvents.g.h
@@ -4345,9 +4345,10 @@ __declspec(noinline) void DispatchTheEvent(const EventAttachInfo& eai, const win
     }
     return winrt::event_token{0};
   } },
+  {"ContentDialogClosed", nullptr /* synthetic event */},
 };
 
-static_assert(ARRAYSIZE(EventInfo::xamlEventMap) == 330);
+static_assert(ARRAYSIZE(EventInfo::xamlEventMap) == 331);
 
 void JsEvent(winrt::Microsoft::ReactNative::IJSValueWriter const& constantWriter, std::wstring topName, std::wstring onName) {
     constantWriter.WritePropertyName(topName);

--- a/package/windows/ReactNativeXaml/Codegen/Version.g.h
+++ b/package/windows/ReactNativeXaml/Codegen/Version.g.h
@@ -7,4 +7,4 @@ THIS FILE WAS AUTOMATICALLY GENERATED, DO NOT MODIFY MANUALLY
 #define VERSION_MAJOR               0
 #define VERSION_MINOR               0
 #define VERSION_REVISION            0
-#define VERSION_BUILD               69
+#define VERSION_BUILD               70

--- a/package/windows/ReactNativeXaml/XamlMetadata.cpp
+++ b/package/windows/ReactNativeXaml/XamlMetadata.cpp
@@ -236,6 +236,16 @@ void SetShowState_ContentDialog(const xaml::DependencyObject& dobj, const xaml::
     case 3: // Hidden
       return cd.Hide();
     }
+    op.Completed([cd, context](const IAsyncOperation<ContentDialogResult>& operation, const AsyncStatus& asyncStatus) {
+      if (asyncStatus == AsyncStatus::Completed) {
+        auto result = static_cast<int32_t>(operation.GetResults());
+
+        XamlUIService::FromContext(context).DispatchEvent(cd, L"topContentDialogClosed",
+          [result](const winrt::Microsoft::ReactNative::IJSValueWriter& evtDataWriter) {
+            evtDataWriter.WriteInt64(result);
+          });
+      }
+      });
   }
 }
 


### PR DESCRIPTION
restoring the deleted synthetic ContentDialogClosed since we need the result of the show operation. This needed some codegen reworking now that ContentDialogResult is a real type not a fake enum.

Fixes #227 