### PR TITLE
Enable PackageReference support if available

### DIFF
--- a/.github/workflows/SetUpAppForNuget.ps1
+++ b/.github/workflows/SetUpAppForNuget.ps1
@@ -10,9 +10,11 @@ $AppName = Split-Path $PWD -Leaf
 Write-Host  App name = $AppName
 $ns = "http://schemas.microsoft.com/developer/msbuild/2003"
 
-[xml]$packagesConfig = Get-Content .\windows\$AppName\packages.config
-($packagesConfig.packages.package | Where-Object id -EQ 'Microsoft.UI.Xaml').version = $WinUIVersion.ToString()
-$packagesConfig.Save("$PWD\windows\$AppName\packages.config")
+if (Test-Path .\windows\$AppName\packages.config) {
+  [xml]$packagesConfig = Get-Content .\windows\$AppName\packages.config
+  ($packagesConfig.packages.package | Where-Object id -EQ 'Microsoft.UI.Xaml').version = $WinUIVersion.ToString()
+  $packagesConfig.Save("$PWD\windows\$AppName\packages.config")
+}
 
 [xml]$EF = Get-Content .\windows\ExperimentalFeatures.props
 $node = $EF.Project.PropertyGroup.WinUI2xVersion

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        useNuGet: [false, true] # test building with both RNW source and RNW NuGet
+        rnwSource: ['Source', 'NuGet'] # test building with both RNW source and RNW NuGet
         rnwVersion: ['^0.64', '^0.69'] # test key versions
     steps:
     - uses: actions/checkout@v2
@@ -82,8 +82,8 @@ jobs:
     - name: create ${{ matrix.rnwVersion }} app
       run: npx react-native init testrnx --template react-native@${{ matrix.rnwVersion }}
 
-    - name: add Windows
-      run: npx react-native-windows-init --overwrite --experimentalNuGetDependency ${{ matrix.useNuGet }}
+    - name: add Windows (RNW via ${{ matrix.rnwSource }})
+      run: npx react-native-windows-init --overwrite ${{ matrix.rnwSource == 'Source' && '--experimentalNuGetDependency true' || '' }}
       working-directory: testrnx
 
     - name: link react-native-xaml
@@ -99,7 +99,7 @@ jobs:
       working-directory: testrnx
 
     - name: update WinUI package version
-      run: ..\.github\workflows\SetUpAppForNuget.ps1 ${{ matrix.useNuGet && '-UseNuGet' || '' }}
+      run: ..\.github\workflows\SetUpAppForNuget.ps1 ${{ matrix.rnwSource == 'NuGet' && '-UseNuGet' || '' }}
       working-directory: testrnx
 
     - name: build app

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
       run: npx react-native init testrnx --template react-native@${{ matrix.rnwVersion }}
 
     - name: add Windows (RNW via ${{ matrix.rnwSource }})
-      run: npx react-native-windows-init --overwrite ${{ matrix.rnwSource == 'Source' && '--experimentalNuGetDependency true' || '' }}
+      run: npx react-native-windows-init --overwrite ${{ matrix.rnwSource == 'NuGet' && '--experimentalNuGetDependency true' || '' }}
       working-directory: testrnx
 
     - name: link react-native-xaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,11 @@ jobs:
 
   testcli:
     runs-on: windows-2019
+    strategy:
+      fail-fast: false
+      matrix:
+        useNuGet: [false, true] # test building with both RNW source and RNW NuGet
+        rnwVersion: ['^0.64', '^0.69'] # test key versions
     steps:
     - uses: actions/checkout@v2
     - name: yarn install
@@ -74,11 +79,11 @@ jobs:
       run: yarn link
       working-directory: package
 
-    - name: create 0.64 app
-      run: npx react-native init testrnx --template react-native@^0.64
+    - name: create ${{ matrix.rnwVersion }} app
+      run: npx react-native init testrnx --template react-native@${{ matrix.rnwVersion }}
 
     - name: add Windows
-      run: npx react-native-windows-init --overwrite
+      run: npx react-native-windows-init --overwrite --experimentalNuGetDependency ${{ matrix.useNuGet }}
       working-directory: testrnx
 
     - name: link react-native-xaml
@@ -94,49 +99,7 @@ jobs:
       working-directory: testrnx
 
     - name: update WinUI package version
-      run: ..\.github\workflows\SetUpAppForNuget.ps1
-      working-directory: testrnx
-
-    - name: build app
-      run: npx react-native run-windows --no-launch --no-deploy --no-packager --logging
-      working-directory: testrnx
-
-
-  testcliNuGet:
-    runs-on: windows-2019
-    steps:
-    - uses: actions/checkout@v2
-    - name: yarn install
-      run: yarn install
-
-    - name: build TS
-      run: yarn build
-
-    - name: yarn link
-      run: yarn link
-      working-directory: package
-
-    - name: create 0.64 app
-      run: npx react-native init testrnx --template react-native@^0.64
-
-    - name: add Windows
-      run: npx react-native-windows-init --overwrite --experimentalNuGetDependency true
-      working-directory: testrnx
-
-    - name: link react-native-xaml
-      run: yarn link react-native-xaml
-      working-directory: testrnx
-
-    - name: add react-native-xaml
-      run: yarn add react-native-xaml
-      working-directory: testrnx
-
-    - name: autolink
-      run: npx react-native autolink-windows --logging
-      working-directory: testrnx
-
-    - name: update WinUI package version and mark for NuGet package consumption
-      run: ..\.github\workflows\SetUpAppForNuget.ps1 -UseNuGet
+      run: ..\.github\workflows\SetUpAppForNuget.ps1 ${{ matrix.useNuGet && '-UseNuGet' || '' }}
       working-directory: testrnx
 
     - name: build app

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         rnwSource: ['Source', 'NuGet'] # test building with both RNW source and RNW NuGet
-        rnwVersion: ['^0.64', '^0.69'] # test key versions
+        rnwVersion: ['^0.64', '^0.67', '^0.69'] # test key versions (min, partners)
     steps:
     - uses: actions/checkout@v2
     - name: yarn install

--- a/change/react-native-xaml-8fc0e6e6-482a-4c20-85c0-d1e46247b16b.json
+++ b/change/react-native-xaml-8fc0e6e6-482a-4c20-85c0-d1e46247b16b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Enable PackageReference support if available",
+  "packageName": "react-native-xaml",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj
+++ b/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props')" />
-  <PropertyGroup>
-    <CppWinRTVersion Condition="'$(CppWinRTVersion)'==''">2.0.210309.3</CppWinRTVersion>
+  <PropertyGroup Label="ReactNativeWindowsProps">
+    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
   </PropertyGroup>
-  <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <ImportGroup Label="ReactNativeWindowsPropertySheets">
+    <Import Project="$(ReactNativeWindowsDir)\PropertySheets\external\Microsoft.ReactNative.Uwp.CppLib.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.props')" />
+  </ImportGroup>
+  <PropertyGroup>
+    <RnwUsesPackageReference Condition="$(RnwUsesPackageReference)=='' And $([MSBuild]::VersionGreaterThanOrEquals('$(ReactNativeWindowsVersion)', '0.68.0'))">true</RnwUsesPackageReference>
+  </PropertyGroup>
+  <PropertyGroup>
+    <CppWinRTVersion Condition="'$(CppWinRTVersion)'=='' Or $([MSBuild]::VersionLessThan('$(CppWinRTVersion)', '2.0.210309.3'))">2.0.210309.3</CppWinRTVersion>
+  </PropertyGroup>
+  <Import Project="$(SolutionDir)\packages\$(WinUIPackageProps)" Condition="$(RnwUsesPackageReference)!='true' And '$(WinUIPackageProps)'!='' And Exists('$(SolutionDir)\packages\$(WinUIPackageProps)')" />
+  <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.props" Condition="$(RnwUsesPackageReference)!='true' And Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -21,9 +31,6 @@
     <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Label="ReactNativeWindowsProps">
-    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
-  </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -80,10 +87,6 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="PropertySheet.props" />
-  </ImportGroup>
-  <ImportGroup Label="ReactNativeWindowsPropertySheets">
-    <Import Project="$(ReactNativeWindowsDir)\PropertySheets\external\Microsoft.ReactNative.Uwp.CppLib.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.props')" />
-    <Import Project="$(SolutionDir)\packages\$(WinUIPackageProps)" Condition="'$(WinUIPackageProps)'!='' And Exists('$(SolutionDir)\packages\$(WinUIPackageProps)')" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup>
@@ -235,6 +238,10 @@
   </ItemGroup>
   <Import Project="$(SolutionDir)\ReactNativeXaml.Imports.props" Condition="Exists('$(SolutionDir)\ReactNativeXaml.Imports.props')" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ItemGroup Condition="$(RnwUsesPackageReference)=='true'">
+    <PackageReference Include="CDebug" Version="0.0.3" />
+    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
+  </ItemGroup>
   <ImportGroup Label="ReactNativeWindowsTargets">
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.targets')" />
   </ImportGroup>
@@ -245,14 +252,14 @@
     <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.props'))" />
     <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.targets'))" />
   </Target>
-  <ImportGroup Label="ExtensionTargets">
+  <ImportGroup Label="ExtensionTargets" Condition="$(RnwUsesPackageReference)!='true'">
     <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="$(SolutionDir)\packages\CDebug.0.0.3\build\CDebug.targets" Condition="Exists('$(SolutionDir)\packages\CDebug.0.0.3\build\CDebug.targets')" />
     <Import Project="$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
     <Import Project="$(SolutionDir)\packages\Microsoft.ReactNative.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.targets" Condition="'$(UseExperimentalNuget)'=='true' And Exists('$(SolutionDir)\packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets')" />
     <Import Project="$(SolutionDir)\packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets" Condition="'$(UseExperimentalNuget)'=='true' And Exists('$(SolutionDir)\packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets')" />
   </ImportGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild" Condition="$(RnwUsesPackageReference)!='true'">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>

--- a/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj
+++ b/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj
@@ -8,7 +8,7 @@
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\external\Microsoft.ReactNative.Uwp.CppLib.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.props')" />
   </ImportGroup>
   <PropertyGroup>
-    <RnwUsesPackageReference Condition="$(RnwUsesPackageReference)=='' And $([MSBuild]::VersionGreaterThanOrEquals('$(ReactNativeWindowsVersion)', '0.68.0'))">true</RnwUsesPackageReference>
+    <RnwUsesPackageReference Condition="$(RnwUsesPackageReference)=='' And $(ReactNativeWindowsVersion)!='' And $([MSBuild]::VersionGreaterThanOrEquals('$(ReactNativeWindowsVersion)', '0.68.0'))">true</RnwUsesPackageReference>
   </PropertyGroup>
   <PropertyGroup>
     <CppWinRTVersion Condition="'$(CppWinRTVersion)'=='' Or $([MSBuild]::VersionLessThan('$(CppWinRTVersion)', '2.0.210309.3'))">2.0.210309.3</CppWinRTVersion>

--- a/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj
+++ b/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <CppWinRTVersion Condition="'$(CppWinRTVersion)'=='' Or $([MSBuild]::VersionLessThan('$(CppWinRTVersion)', '2.0.210309.3'))">2.0.210309.3</CppWinRTVersion>
   </PropertyGroup>
-  <Import Project="$(SolutionDir)\packages\$(WinUIPackageProps)" Condition="$(RnwUsesPackageReference)!='true' And '$(WinUIPackageProps)'!='' And Exists('$(SolutionDir)\packages\$(WinUIPackageProps)')" />
+  <Import Project="$(SolutionDir)\packages\$(WinUIPackageProps)" Condition="$(RnwUsesPackageReference)!='true' And '$(OverrideWinUIPackage)'!='true' And '$(WinUIPackageProps)'!='' And Exists('$(SolutionDir)\packages\$(WinUIPackageProps)')" />
   <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.props" Condition="$(RnwUsesPackageReference)!='true' And Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -255,7 +255,7 @@
   <ImportGroup Label="ExtensionTargets" Condition="$(RnwUsesPackageReference)!='true'">
     <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="$(SolutionDir)\packages\CDebug.0.0.3\build\CDebug.targets" Condition="Exists('$(SolutionDir)\packages\CDebug.0.0.3\build\CDebug.targets')" />
-    <Import Project="$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
+    <Import Project="$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="'$(OverrideWinUIPackage)'!='true' And Exists('$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
     <Import Project="$(SolutionDir)\packages\Microsoft.ReactNative.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.targets" Condition="'$(UseExperimentalNuget)'=='true' And Exists('$(SolutionDir)\packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets')" />
     <Import Project="$(SolutionDir)\packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets" Condition="'$(UseExperimentalNuget)'=='true' And Exists('$(SolutionDir)\packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets')" />
   </ImportGroup>
@@ -266,7 +266,7 @@
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\CDebug.0.0.3\build\CDebug.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\CDebug.0.0.3\build\CDebug.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets'))" />
+    <Error Condition="'$(OverrideWinUIPackage)'!='true' And !Exists('$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets'))" />
     <Error Condition="'$(UseExperimentalNuget)'=='true' And !Exists('$(SolutionDir)\packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets'))" />
     <Error Condition="'$(UseExperimentalNuget)'=='true' And !Exists('$(SolutionDir)\packages\Microsoft.ReactNative.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.ReactNative.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.targets'))" />
   </Target>


### PR DESCRIPTION
This PR checks if the version of RNW is >= 0.68.0, then switches to using
`PackageReference` for NuGet dependencies instead of using the legacy
`packages.config`.

This PR also updates the GitHub Action workflow to reduce copy/pasting and expand the test matrix of RNW versions tested.

Closes #230
Closes #231

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-xaml/pull/232)