### PR TITLE
Add target to optionally run CodeGen before ReactNativeXaml build

### DIFF
--- a/change/react-native-xaml-a8381afc-a56c-4494-957c-ee7962956d9a.json
+++ b/change/react-native-xaml-a8381afc-a56c-4494-957c-ee7962956d9a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add target to optionally run CodeGen before ReactNativeXaml build",
+  "packageName": "react-native-xaml",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package/windows/ExperimentalFeatures.props
+++ b/package/windows/ExperimentalFeatures.props
@@ -8,4 +8,9 @@
     <WinUI2xVersion>2.6.0</WinUI2xVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Setting this to true here so we're sure to run the codegen when working within the RNX repo itself. -->
+    <RunReactNativeXamlCodeGenBeforeBuild>true</RunReactNativeXamlCodeGenBeforeBuild>
+  </PropertyGroup>
+
 </Project>

--- a/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj
+++ b/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj
@@ -245,6 +245,18 @@
     <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.props'))" />
     <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.targets'))" />
   </Target>
+  <PropertyGroup Label="ReactNativeXamlCodeGenProps">
+    <RunReactNativeXamlCodeGenBeforeBuild Condition="$(RunReactNativeXamlCodeGenBeforeBuild)==''">false</RunReactNativeXamlCodeGenBeforeBuild>
+    <ReactNativeXamlTargetWinMD Condition="$(ReactNativeXamlTargetWinMD)=='' And $(RnwUsesPackageReference)=='true' And Exists('$(NuGetPackageRoot)\$(WinUIPackageName)\$(WinUIPackageVersion)\lib\uap10.0\Microsoft.UI.Xaml.winmd')">$(NuGetPackageRoot)\$(WinUIPackageName)\$(WinUIPackageVersion)\lib\uap10.0\Microsoft.UI.Xaml.winmd</ReactNativeXamlTargetWinMD>
+    <ReactNativeXamlTargetWinMD Condition="$(ReactNativeXamlTargetWinMD)=='' And $(RnwUsesPackageReference)!='true' And Exists('$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\lib\uap10.0\Microsoft.UI.Xaml.winmd')">$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\lib\uap10.0\Microsoft.UI.Xaml.winmd</ReactNativeXamlTargetWinMD>
+    <ReactNativeXamlRootDir Condition="$(ReactNativeXamlRootDir)==''">$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)..\..\'))</ReactNativeXamlRootDir>
+    <ReactNativeXamlCodeGenCommand Condition="$(ReactNativeXamlCodeGenCommand)==''">dotnet run --project Codegen -verbose -winmd $(ReactNativeXamlTargetWinMD)</ReactNativeXamlCodeGenCommand>
+    <ReactNativeXamlYarnBuildCommand Condition="$(ReactNativeXamlYarnBuildCommand)==''">yarn build</ReactNativeXamlYarnBuildCommand>
+  </PropertyGroup>
+  <Target Name="RunReactNativeXamlCodeGen" BeforeTargets="PrepareForBuild" Condition="$(RunReactNativeXamlCodeGenBeforeBuild)=='true'">
+    <Exec Command="$(ReactNativeXamlCodeGenCommand)" WorkingDirectory="$(ReactNativeXamlRootDir)" CustomWarningRegularExpression="Warning: " CustomErrorRegularExpression="Error: " />
+    <Exec Command="$(ReactNativeXamlYarnBuildCommand)" WorkingDirectory="$(ReactNativeXamlRootDir)" CustomWarningRegularExpression="Warning: " CustomErrorRegularExpression="Error: " />
+  </Target>
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="$(SolutionDir)\packages\CDebug.0.0.3\build\CDebug.targets" Condition="Exists('$(SolutionDir)\packages\CDebug.0.0.3\build\CDebug.targets')" />

--- a/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj
+++ b/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj
@@ -260,7 +260,18 @@
     <ReactNativeXamlCodeGenCommand Condition="$(ReactNativeXamlCodeGenCommand)==''">dotnet run --project Codegen -verbose -winmd $(ReactNativeXamlTargetWinMD)</ReactNativeXamlCodeGenCommand>
     <ReactNativeXamlYarnBuildCommand Condition="$(ReactNativeXamlYarnBuildCommand)==''">yarn build</ReactNativeXamlYarnBuildCommand>
   </PropertyGroup>
-  <Target Name="RunReactNativeXamlCodeGen" BeforeTargets="PrepareForBuild" Condition="$(RunReactNativeXamlCodeGenBeforeBuild)=='true'">
+  <ItemGroup>
+    <RnxCodeGenOutput Include="Codegen\EventArgsTypeProperties.g.h" />
+    <RnxCodeGenOutput Include="Codegen\TypeCreator.g.cpp" />
+    <RnxCodeGenOutput Include="Codegen\TypeEnums.g.h" />
+    <RnxCodeGenOutput Include="Codegen\TypeEvents.g.h" />
+    <RnxCodeGenOutput Include="Codegen\TypeProperties.g.h" />
+    <RnxCodeGenOutput Include="Codegen\Version.g.h" />
+    <RnxCodeGenOutput Include="..\..\src\Enums.ts" />
+    <RnxCodeGenOutput Include="..\..\src\Props.ts" />
+    <RnxCodeGenOutput Include="..\..\src\Types.tsx" />
+  </ItemGroup>
+  <Target Name="RunReactNativeXamlCodeGen" BeforeTargets="PrepareForBuild" Condition="$(RunReactNativeXamlCodeGenBeforeBuild)=='true'" Inputs="$(ReactNativeXamlTargetWinMD)" Outputs="@(RnxCodeGenOutput)">
     <Exec Command="$(ReactNativeXamlCodeGenCommand)" WorkingDirectory="$(ReactNativeXamlRootDir)" CustomWarningRegularExpression="Warning: " CustomErrorRegularExpression="Error: " />
     <Exec Command="$(ReactNativeXamlYarnBuildCommand)" WorkingDirectory="$(ReactNativeXamlRootDir)" CustomWarningRegularExpression="Warning: " CustomErrorRegularExpression="Error: " />
   </Target>


### PR DESCRIPTION
This PR adds some new MSBuild properties and targets within ReactNativeXaml.vcxproj to support re-running the CodeGen before the build.

By setting a property in their ExperimentalFeatures.props file:

```xml
<RunReactNativeXamlCodeGenBeforeBuild>true</RunReactNativeXamlCodeGenBeforeBuild>
```

Customers can make sure the CodeGen tool runs before the native build. It's default to `false` since most customers don't need it. However, this will hopefully address https://github.com/microsoft/react-native-windows/issues/10792, which was a hack to get the same effect.

Note that customers can also customize how the CodeGen runs, in particular, by specifying a different `ReactNativeXamlTargetWinMD` file if desired.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-xaml/pull/234)