### PR TITLE
Upgrade to WinUI 2.7

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Alexander Sklar
+Copyright (c) Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/change/react-native-xaml-a5d640ee-506a-4d00-aaa1-3a2b931ea4c4.json
+++ b/change/react-native-xaml-a5d640ee-506a-4d00-aaa1-3a2b931ea4c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Upgrade to WinUI 2.7",
+  "packageName": "react-native-xaml",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package/LICENSE
+++ b/package/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Alexander Sklar
+Copyright (c) Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package/README.md
+++ b/package/README.md
@@ -6,7 +6,7 @@
 
 Ensure you're using React Native Windows >= 0.67.11.
 
-Ensure your app is using WinUI 2.6+. For details about customizing WinUI versions in your React Native for Windows app, see [Customizing SDK versions](https://microsoft.github.io/react-native-windows/docs/customizing-sdk-versions).
+Ensure your app is using WinUI 2.7+. For details about customizing WinUI versions in your React Native for Windows app, see [Customizing SDK versions](https://microsoft.github.io/react-native-windows/docs/customizing-sdk-versions).
 
 ### Mostly automatic installation
 


### PR DESCRIPTION
This PR is to capture that the codegen was retargeted to WinUI 2.7 (to align with the supported versions of RNW).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-xaml/pull/246)