### PR TITLE
Avoid throwing away native module calls

### DIFF
--- a/change/react-native-xaml-2081187e-e006-4295-a34d-3985fb4ebe93.json
+++ b/change/react-native-xaml-2081187e-e006-4295-a34d-3985fb4ebe93.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Avoid throwing away native module calls.",
+  "packageName": "react-native-xaml",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package/Codegen/TypeEvents.cs
+++ b/package/Codegen/TypeEvents.cs
@@ -76,7 +76,7 @@ THIS FILE WAS AUTOMATICALLY GENERATED, DO NOT MODIFY MANUALLY
                     "atchTheEvent(const EventAttachInfo& eai, const winrt::Windows::Foundation::IInsp" +
                     "ectable& sender, const T& args) {\r\n  auto senderAsFE = sender.try_as<FrameworkEl" +
                     "ement>();\r\n  auto wEN = winrt::to_hstring(eai.jsEventName);\r\n  if (eai.xamlMetad" +
-                    "ata.m_callFunctionReturnFlushedQueue.has_value()) {\r\n    const auto tag = XamlMe" +
+                    "ata.m_receiveEvent.has_value()) {\r\n    const auto tag = XamlMe" +
                     "tadata::TagFromElement(eai.obj.as<xaml::DependencyObject>());\r\n    ExecuteJsi(ea" +
                     "i.context, [metadata = eai.xamlMetadata.shared_from_this(), tag, senderAsFE, arg" +
                     "s, eventName = eai.jsEventName](facebook::jsi::Runtime& rt) {\r\n      auto objSen" +

--- a/package/Codegen/TypeEvents.tt
+++ b/package/Codegen/TypeEvents.tt
@@ -34,7 +34,7 @@ template<typename T>
 __declspec(noinline) void DispatchTheEvent(const EventAttachInfo& eai, const winrt::Windows::Foundation::IInspectable& sender, const T& args) {
   auto senderAsFE = sender.try_as<FrameworkElement>();
   auto wEN = winrt::to_hstring(eai.jsEventName);
-  if (eai.xamlMetadata.m_callFunctionReturnFlushedQueue.has_value()) {
+  if (eai.xamlMetadata.m_receiveEvent.has_value()) {
     const auto tag = XamlMetadata::TagFromElement(eai.obj.as<xaml::DependencyObject>());
     ExecuteJsi(eai.context, [metadata = eai.xamlMetadata.shared_from_this(), tag, senderAsFE, args, eventName = eai.jsEventName](facebook::jsi::Runtime& rt) {
       auto objSender = std::make_shared<XamlObject>(senderAsFE, metadata);

--- a/package/windows/ReactNativeXaml/Codegen/TypeEvents.g.h
+++ b/package/windows/ReactNativeXaml/Codegen/TypeEvents.g.h
@@ -34,7 +34,7 @@ template<typename T>
 __declspec(noinline) void DispatchTheEvent(const EventAttachInfo& eai, const winrt::Windows::Foundation::IInspectable& sender, const T& args) {
   auto senderAsFE = sender.try_as<FrameworkElement>();
   auto wEN = winrt::to_hstring(eai.jsEventName);
-  if (eai.xamlMetadata.m_callFunctionReturnFlushedQueue.has_value()) {
+  if (eai.xamlMetadata.m_receiveEvent.has_value()) {
     const auto tag = XamlMetadata::TagFromElement(eai.obj.as<xaml::DependencyObject>());
     ExecuteJsi(eai.context, [metadata = eai.xamlMetadata.shared_from_this(), tag, senderAsFE, args, eventName = eai.jsEventName](facebook::jsi::Runtime& rt) {
       auto objSender = std::make_shared<XamlObject>(senderAsFE, metadata);

--- a/package/windows/ReactNativeXaml/XamlMetadata.h
+++ b/package/windows/ReactNativeXaml/XamlMetadata.h
@@ -235,7 +235,8 @@ struct XamlMetadata : std::enable_shared_from_this<XamlMetadata> {
   void PopulateCommands(const winrt::Windows::Foundation::Collections::IVector<winrt::hstring>& commands) const;
 
   void JsiDispatchEvent(facebook::jsi::Runtime& rt, int64_t viewTag, std::string&& eventName, std::shared_ptr<facebook::jsi::Object>& eventData) const noexcept;
-  std::optional<facebook::jsi::Function> m_callFunctionReturnFlushedQueue;
+  std::optional<facebook::jsi::Function> m_receiveEvent;
+  std::optional<facebook::jsi::Object> m_eventEmitter;
   winrt::Microsoft::ReactNative::IReactDispatcher UIDispatcher() const { return m_reactContext.UIDispatcher(); }
   xaml::DependencyObject ElementFromTag(int64_t tag) const { return winrt::Microsoft::ReactNative::XamlUIService::FromContext(m_reactContext).ElementFromReactTag(tag); }
   static int64_t TagFromElement(xaml::DependencyObject const& element);


### PR DESCRIPTION
The current implementation of `JsiDispatchEvent` calls directly into `callFunctionReturnFlushedQueue` to trigger a call into the JS code.  Unfortunately, this call returns an array which is a list of native module calls which should be made.  But this code is not able to call those native modules since that code is not exposed.  So instead, there are just a set of native module calls which never get called.

This PR replaces the call to `callFunctionReturnFlushedQueue` with a call directly into the `RCTEventEmitter.receiveEvent` function, which will not do the flush.

The flush will be done by the `ExecuteJsi` function, which will correctly flush and call the native modules returned.

Fixes https://github.com/microsoft/react-native-xaml/issues/247

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-xaml/pull/248)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-xaml/pull/248)