### PR TITLE
Add required PR Check action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,4 +90,4 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setupcheck, call-runcodegen, call-testcli, call-testcli-old, call-buildnpmpackage, call-buildrnx]
     steps:
-     - uses: alex-sandri/nothing-action@v1.1
+     - uses: actions/checkout@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -84,3 +84,10 @@ jobs:
       vmImage: windows-2022
       configuration: ${{ matrix.configuration }}
       platform: ${{ matrix.platform }}
+
+  prcheck:
+    name: Successful PR Check
+    runs-on: ubuntu-latest
+    needs: [setupcheck, call-runcodegen, call-testcli, call-testcli-old, call-buildnpmpackage, call-buildrnx]
+    steps:
+     - uses: alex-sandri/nothing-action@v1.1


### PR DESCRIPTION
Our PR jobs now call into templates and use a matrix strategy for all tested configurations.

GitHub Actions branch protections do not let you set "all jobs are required" nor even "all matrix permutations of this one job" are required.

You literally have to set every individual permutation as required manually, which makes it hard to maintain.

This PR adds a final "Successful PR Check" job that is dependent on all the others, that can be the *one* set to required.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-xaml/pull/249)