### PR TITLE
Fix missing TS dependency for RN < 0.71

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
       vmImage: windows-2022
       rnwVersion: ${{ matrix.rnwVersion }}
       useRnwNuGet: ${{ matrix.useRnwNuGet }}
+      rnTemplate: ${{ matrix.rnTemplate }}
     
   call-testcli-old:
     name: Test CLI (VS 2019)
@@ -64,6 +65,7 @@ jobs:
       vmImage: windows-2019
       rnwVersion: ${{ matrix.rnwVersion }}
       useRnwNuGet: ${{ matrix.useRnwNuGet }}
+      rnTemplate: ${{ matrix.rnTemplate }}
 
   call-buildnpmpackage:
     name: Build NPM Package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,8 +30,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rnwVersion: [ '0.71-stable', 'latest'] # test *all* versions that use VS 2022. aka any RNW version >= min in package.json and >= 0.71
+        rnwVersion: [ '0.72-stable', '0.71-stable'] # test *all* versions that use VS 2022. aka any RNW version >= min in package.json and >= 0.71
         useRnwNuGet: [false, true] # test building with both RNW source and RNW NuGet
+        include:
+          - rnwVersion: '0.72-stable'
+            rnTemplate: 'react-native@0.72-stable'
+          - rnwVersion: '0.71-stable'
+            rnTemplate: 'react-native@0.71-stable'
     uses: ./.github/workflows/template-testcli.yml
     with:
       vmImage: windows-2022
@@ -43,8 +48,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rnwVersion: ['0.67-stable', '0.68-stable', '0.69-stable', '0.70-stable'] # test *all* versions that use VS 2019. aka any RNW version >= min in package.json and < 0.71
+        rnwVersion: ['0.70-stable', '0.69-stable', '0.68-stable', '0.67-stable'] # test *all* versions that use VS 2019. aka any RNW version >= min in package.json and < 0.71
         useRnwNuGet: [false, true] # test building with both RNW source and RNW NuGet
+      include:
+          - rnwVersion: '0.70-stable'
+            rnTemplate: 'react-native-template-typescript@6.12.11'
+          - rnwVersion: '0.69-stable'
+            rnTemplate: 'react-native-template-typescript@6.11.9'
+          - rnwVersion: '0.68-stable'
+            rnTemplate: 'react-native-template-typescript@6.10.4'
+          - rnwVersion: '0.67-stable'
+            rnTemplate: 'react-native-template-typescript@6.9.6'
     uses: ./.github/workflows/template-testcli.yml
     with:
       vmImage: windows-2019

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,8 +42,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rnwVersion: ['0.71-stable', 'latest'] # test *key* versions that use VS 2022. aka any RNW version >= 0.71 used by supported partners and/or Active/Maintenance from https://microsoft.github.io/react-native-windows/support
+        rnwVersion: ['0.72-stable', '0.71-stable'] # test *key* versions that use VS 2022. aka any RNW version >= 0.71 used by supported partners and/or Active/Maintenance from https://microsoft.github.io/react-native-windows/support
         useRnwNuGet: [false, true] # test building with both RNW source and RNW NuGet
+        include:
+          - rnwVersion: '0.72-stable'
+            rnTemplate: 'react-native@0.72-stable'
+          - rnwVersion: '0.71-stable'
+            rnTemplate: 'react-native@0.71-stable'
     uses: ./.github/workflows/template-testcli.yml
     with:
       vmImage: windows-2022
@@ -56,8 +61,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rnwVersion: ['0.67-stable', '0.69-stable'] # test *key* versions that use VS 2019. aka any RNW version < 0.71 that are used by supported partners
+        rnwVersion: ['0.69-stable', '0.67-stable'] # test *key* versions that use VS 2019. aka any RNW version < 0.71 that are used by supported partners
         useRnwNuGet: [false, true] # test building with both RNW source and RNW NuGet
+        include:
+          - rnwVersion: '0.69-stable'
+            rnTemplate: 'react-native-template-typescript@6.11.9'
+          - rnwVersion: '0.67-stable'
+            rnTemplate: 'react-native-template-typescript@6.9.6'
     uses: ./.github/workflows/template-testcli.yml
     with:
       vmImage: windows-2019

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,6 +54,7 @@ jobs:
       vmImage: windows-2022
       rnwVersion: ${{ matrix.rnwVersion }}
       useRnwNuGet: ${{ matrix.useRnwNuGet }}
+      rnTemplate: ${{ matrix.rnTemplate }}
     
   call-testcli-old:
     name: Test CLI (VS 2019)
@@ -73,6 +74,7 @@ jobs:
       vmImage: windows-2019
       rnwVersion: ${{ matrix.rnwVersion }}
       useRnwNuGet: ${{ matrix.useRnwNuGet }}
+      rnTemplate: ${{ matrix.rnTemplate }}
 
   call-buildnpmpackage:
     name: Build NPM Package

--- a/.github/workflows/template-testcli.yml
+++ b/.github/workflows/template-testcli.yml
@@ -15,6 +15,10 @@ on:
         required: false
         default: false
         type: boolean
+      rnTemplate:
+        required: false
+        default: 'react-native@latest'
+        type: string
 
 jobs:
   testcli:
@@ -34,7 +38,7 @@ jobs:
       working-directory: package
 
     - name: create react-native@${{ inputs.rnwVersion }} app
-      run: npx react-native init testrnx --template react-native@${{ inputs.rnwVersion }}
+      run: npx react-native init testrnx --template ${{ inputs.rnTemplate }}
       working-directory: ../
 
     - name: add Windows (RNW via ${{ inputs.useRnwNuGet && 'NuGet' || 'Source' }})


### PR DESCRIPTION
Now that typescript types are included in RN, they've deprecated the package `@types/react-native`, which unfortunately breaks creating new test apps for RN < 0.71 because RNX needs the types to do its codegen and they're no longer available.

This PR fixes our CI/PR workflows to use the typescript templates for the older versions so we get typescript and the proper RN types.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-xaml/pull/272)