### PR TITLE
Require RNW >= 0.69.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,17 +51,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rnwVersion: ['0.70-stable', '0.69-stable', '0.68-stable', '0.67-stable'] # test *all* versions that use VS 2019. aka any RNW version >= min in package.json and < 0.71
+        rnwVersion: ['0.70-stable', '0.69-stable'] # test *all* versions that use VS 2019. aka any RNW version >= min in package.json and < 0.71
         useRnwNuGet: [false, true] # test building with both RNW source and RNW NuGet
         include:
           - rnwVersion: '0.70-stable'
             rnTemplate: 'react-native-template-typescript@6.12.11'
           - rnwVersion: '0.69-stable'
             rnTemplate: 'react-native-template-typescript@6.11.9'
-          - rnwVersion: '0.68-stable'
-            rnTemplate: 'react-native-template-typescript@6.10.4'
-          - rnwVersion: '0.67-stable'
-            rnTemplate: 'react-native-template-typescript@6.9.6'
     uses: ./.github/workflows/template-testcli.yml
     with:
       vmImage: windows-2019

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,15 +42,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rnwVersion: ['latest', '0.72-stable', '0.71-stable'] # test *key* versions that use VS 2022. aka any RNW version >= 0.71 used by supported partners and/or Active/Maintenance from https://microsoft.github.io/react-native-windows/support
+        rnwVersion: ['latest', '0.72-stable'] # test *key* versions that use VS 2022. aka any RNW version >= 0.71 used by supported partners and/or Active/Maintenance from https://microsoft.github.io/react-native-windows/support
         useRnwNuGet: [false, true] # test building with both RNW source and RNW NuGet
         include:
           - rnwVersion: 'latest'
             rnTemplate: 'react-native@latest'
           - rnwVersion: '0.72-stable'
             rnTemplate: 'react-native@0.72-stable'
-          - rnwVersion: '0.71-stable'
-            rnTemplate: 'react-native@0.71-stable'
     uses: ./.github/workflows/template-testcli.yml
     with:
       vmImage: windows-2022
@@ -64,13 +62,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rnwVersion: ['0.69-stable', '0.67-stable'] # test *key* versions that use VS 2019. aka any RNW version < 0.71 that are used by supported partners
+        rnwVersion: ['0.69-stable'] # test *key* versions that use VS 2019. aka any RNW version < 0.71 that are used by supported partners
         useRnwNuGet: [false, true] # test building with both RNW source and RNW NuGet
         include:
           - rnwVersion: '0.69-stable'
             rnTemplate: 'react-native-template-typescript@6.11.9'
-          - rnwVersion: '0.67-stable'
-            rnTemplate: 'react-native-template-typescript@6.9.6'
     uses: ./.github/workflows/template-testcli.yml
     with:
       vmImage: windows-2019

--- a/change/react-native-xaml-4147834d-ad37-47d7-83bc-245271fe2778.json
+++ b/change/react-native-xaml-4147834d-ad37-47d7-83bc-245271fe2778.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Require RNW >= 0.69.0",
+  "packageName": "react-native-xaml",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package/package.json
+++ b/package/package.json
@@ -36,9 +36,9 @@
     "@types/react-native": "*"
   },
   "peerDependencies": {
-    "react": ">= 17.0.2",
-    "react-native": ">= 0.67.0",
-    "react-native-windows": ">= 0.67.11",
+    "react": ">= 18.0.0",
+    "react-native": ">= 0.69.0",
+    "react-native-windows": ">= 0.69.0",
     "typescript": "^4.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR bumps the minimum required/supported version of react-native and react-native-windows to 0.69.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-xaml/pull/276)