### PR TITLE
@types/react-native has been deprecated, so we should no longer bring it in

### DIFF
--- a/change/react-native-xaml-e7cf68a9-d303-4f2d-8131-7866d5e54c6f.json
+++ b/change/react-native-xaml-e7cf68a9-d303-4f2d-8131-7866d5e54c6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove dependency on @types/react-native",
+  "packageName": "react-native-xaml",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package/package.json
+++ b/package/package.json
@@ -32,8 +32,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "dependencies": {
-    "@types/react": "*",
-    "@types/react-native": "*"
+    "@types/react": "*"
   },
   "peerDependencies": {
     "react": ">= 18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2721,13 +2721,6 @@
   resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
-"@types/react-native@*":
-  version "0.64.12"
-  resolved "https://registry.npmjs.org/@types/react-native/-/react-native-0.64.12.tgz"
-  integrity sha512-sw6WGSaL219zqrgdb4kQUtFB9iGXC/LmecLZ+UUWEgwYvD0YH81FqWYmONa2HuTkOFAsxu2bK4DspkWRUHIABQ==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-test-renderer@^18.0.0":
   version "18.0.0"
   resolved "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz"


### PR DESCRIPTION
react-native provides its own types now.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-xaml/pull/279)