### PR TITLE
Fix MenuFlyout so that it can update when number of child MenuFlyoutItems changes

### DIFF
--- a/.github/change/react-native-xaml-c185b58f-a901-44bb-842b-20547b12601e.2cb625ac.json
+++ b/.github/change/react-native-xaml-c185b58f-a901-44bb-842b-20547b12601e.2cb625ac.json
@@ -1,0 +1,8 @@
+{
+    "type": "patch",
+    "comment": "fix RNX MenuFlyout so that it can update when number of child MenuFlyoutItem changes.",
+    "packageName": "react-native-xaml",
+    "email": "vichaudh@microsoft.com",
+    "dependentChangeType": "patch"
+  }
+  

--- a/package/windows/ReactNativeXaml/XamlViewManager.cpp
+++ b/package/windows/ReactNativeXaml/XamlViewManager.cpp
@@ -346,6 +346,12 @@ void XamlViewManager::RemoveChildAt(xaml::FrameworkElement parent, int64_t index
     return panel.Children().RemoveAt(static_cast<uint32_t>(index));
   } else if (auto itemsControl = e.try_as<ItemsControl>()) {
     return itemsControl.Items().RemoveAt(static_cast<uint32_t>(index));
+  } else if (auto wrapper = e.try_as<Wrapper>()) {
+    if (auto parentContent = wrapper.WrappedObject()) {
+      if (auto menuFlyout = parentContent.try_as<MenuFlyout>()) {
+        return menuFlyout.Items().RemoveAt(static_cast<uint32_t>(index));
+      }
+    }
   } else if (index == 0) {
     if (auto contentCtrl = e.try_as<ContentControl>()) {
       return contentCtrl.Content(nullptr);


### PR DESCRIPTION
There's an issue where if MenuFlyout is shown with N items previously and you attempt to show it again but with only M items, it still shows N items with last item being duplicated. This change fixes this issue.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-xaml/pull/291)