### PR TITLE
Menuflyout fix

### DIFF
--- a/change/react-native-xaml-dba300ac-4cad-41b2-a538-aeeac2e8b0a3.json
+++ b/change/react-native-xaml-dba300ac-4cad-41b2-a538-aeeac2e8b0a3.json
@@ -1,7 +1,7 @@
 {
   "type": "patch",
   "comment": {
-    "title": ""
+    "title": "MenuFlyout fix"
   },
   "packageName": "react-native-xaml",
   "email": "virendra.chaudhary@gmail.com",

--- a/change/react-native-xaml-dba300ac-4cad-41b2-a538-aeeac2e8b0a3.json
+++ b/change/react-native-xaml-dba300ac-4cad-41b2-a538-aeeac2e8b0a3.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": {
+    "title": ""
+  },
+  "packageName": "react-native-xaml",
+  "email": "virendra.chaudhary@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/package/windows/ReactNativeXaml/XamlViewManager.cpp
+++ b/package/windows/ReactNativeXaml/XamlViewManager.cpp
@@ -346,6 +346,12 @@ void XamlViewManager::RemoveChildAt(xaml::FrameworkElement parent, int64_t index
     return panel.Children().RemoveAt(static_cast<uint32_t>(index));
   } else if (auto itemsControl = e.try_as<ItemsControl>()) {
     return itemsControl.Items().RemoveAt(static_cast<uint32_t>(index));
+  } else if (auto wrapper = e.try_as<Wrapper>()) {
+    if (auto parentContent = wrapper.WrappedObject()) {
+      if (auto menuFlyout = parentContent.try_as<MenuFlyout>()) {
+        return menuFlyout.Items().RemoveAt(static_cast<uint32_t>(index));
+      }
+    }
   } else if (index == 0) {
     if (auto contentCtrl = e.try_as<ContentControl>()) {
       return contentCtrl.Content(nullptr);


### PR DESCRIPTION
Currently when number of MenuFlyoutItem change, they don't reflect in the MenuFlyout as expected. For example, if you have a MenuFlyout that looks like this:

![image](https://github.com/user-attachments/assets/53535c1e-6fe3-445f-b8a6-b80a4d4e67a1)

Then something changes that removes Feedback on recommendation to be removed, the MenuFlyout appears like this:

![image](https://github.com/user-attachments/assets/2e760454-7f3b-4b16-b6c7-bd4ac8c7b98b)

instead of like this:
![image](https://github.com/user-attachments/assets/84920501-e6fc-4d3b-bd46-8f9f89c9cc2d)

This PR fixes this issue.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-xaml/pull/292)