### PR TITLE
Fix NuGet errors when consumed by apps

### DIFF
--- a/change/react-native-xaml-3440a323-4329-4f3e-af38-2181f6252927.json
+++ b/change/react-native-xaml-3440a323-4329-4f3e-af38-2181f6252927.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix NuGet errors when consumed by apps",
+  "packageName": "react-native-xaml",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package/.npmignore
+++ b/package/.npmignore
@@ -1,2 +1,3 @@
 example/
 *.tgz
+*.lock.json

--- a/package/.npmignore
+++ b/package/.npmignore
@@ -1,3 +1,0 @@
-example/
-*.tgz
-*.lock.json

--- a/package/package.json
+++ b/package/package.json
@@ -59,6 +59,7 @@
     "windows/",
     "lib/",
     "src/",
-    "!*.ruleset"
+    "!*.ruleset",
+    "!*.lock.json"
   ]
 }

--- a/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj
+++ b/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj
@@ -253,7 +253,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ItemGroup Condition="'$(RnwUsesPackageReference)'=='true'">
     <PackageReference Include="CDebug" Version="0.0.3" />
-    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
+    <PackageReference Update="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
   </ItemGroup>
   <ImportGroup Label="ReactNativeWindowsTargets">
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.targets')" />


### PR DESCRIPTION
This PR fixes our consumption of the `Microsoft.Windows.CppWinRT` package reference to use `Update` instead of `Include` (so at best it "updates" which version to use and doesn't conflict with what RNW wants) and removes the "duplicate reference" warning our customers see.

I'm 99% we don't need the entry at all in newer RNW versions but leaving it for now to deal with older customers.

This PR also removes the NuGet `package.lock.json` file from the published npm package, as it takes the decision to use/respect lock files away from the customer.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-xaml/pull/297)